### PR TITLE
Assorted enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,33 @@ Add this line to your application's Gemfile:
 
 ## Usage
 
-Use it as you would use regular Capybara API, however this time, you won't face any race conditions when working with DOM Mutation JS applications.
+Use it as you would use regular Capybara API, however this time, you won't face
+any race conditions when working with DOM Mutation JS applications.
 
 ```ruby
 RSpec.configure do |config|
-  config.include Capybara::MutationObserver::DSL, type: feature
+  config.include Capybara::MutationObserver::DSL, type: :feature
 end
 ```
 
 ## Tuning
 
+```ruby
+# wait # of unninterupted cycles after javascript stops mutation to consider stable
+Capybara::MutationObserver.default_max_cycles_till_stable = 3
+
+# length of time of a cyle in ms
+Capybara::MutationObserver.default_cycle_length_ms = 250
+
+# consider any mutation to body element as a reset on the mutation timing window
+Capybara::MutationObserver.default_element_selector = "body" # CSS Selector ie: "[ng-app] or elsewise"
+
+# spit out extra logging to JS console
+Capybara::MutationObserver.default_debug = true
 ```
-   	# wait # of unninterupted cycles after javascript stops mutation to consider stable
-   	Capybara::MutationObserver.default_max_cycles_till_stable = 3
 
-   	# length of time of a cyle in ms
-   	Capybara::MutationObserver.default_cycle_length_ms = 250
-   
-   	# consider any mutation to body element as a reset on the mutation timing window
-   	Capybara::MutationObserver.default_element_selector = "body" # CSS Selector ie: "[ng-app] or elsewise"
-
-   	# spit out extra logging to JS console
-   	Capybara::MutationObserver.default_debug = true
-```
-
-
-If you need to run some code without caring about Angular or mutating JS, you can use `ignoring_mutation` like this:
+If you need to run some code without caring about Angular or mutating JS, you
+can use `ignoring_mutation` like this:
 ```ruby
 ignoring_mutation do
   # Your Mutation agnostic code goes here
@@ -44,7 +45,8 @@ end
 
 ## Limitations
 
-At the moment it works with AngularJS applications initialized with `ng-app`. Other frameworks that modify the dom should work aswell however are untested.
+At the moment it works with AngularJS applications initialized with `ng-app`.
+Other frameworks that modify the dom should work aswell however are untested.
 
 Testing with other frameworks like Vue is expected to occur
 
@@ -55,6 +57,3 @@ Testing with other frameworks like Vue is expected to occur
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
-# capybara-mutation-observer
-# capybara-mutation-observer
-# capybara-mutation-observer

--- a/capybara-mutation-observer.gemspec
+++ b/capybara-mutation-observer.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rackup"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "poltergeist"
+  spec.add_development_dependency "cuprite"
   spec.add_development_dependency "puma"
 end

--- a/lib/capybara/mutation_observer/dsl.rb
+++ b/lib/capybara/mutation_observer/dsl.rb
@@ -2,12 +2,6 @@ module Capybara
   module MutationObserver
     module DSL
       include Capybara::DSL
-      Capybara::Session::DSL_METHODS.each do |method|
-        Capybara::MutationObserver.debug("Redefining #{method}")
-        define_method(method) do |*args, &block|
-          page.send(method, *args, &block)
-        end
-      end
 
       def page
         Capybara::MutationObserver.debug("Page Invoked")
@@ -20,12 +14,14 @@ module Capybara
         Waiter.new(Capybara.current_session).wait_until_ready
       end
 
-      def ignoring_mutation
-        @ignoring_mutation = true
-        Capybara::MutationObserver.debug("Ignoring Mutation")
-        yield
+      def ignoring_mutation(value = true)
+        ignoring_mutation_was = @ignoring_mutation
+        if @ignoring_mutation = value
+          Capybara::MutationObserver.debug("Ignoring Mutation")
+        end
+        yield if block_given?
       ensure
-        @ignoring_mutation = false
+        @ignoring_mutation = ignoring_mutation_was if block_given?
       end
     end
   end

--- a/spec/capybara/mutation_observer_spec.rb
+++ b/spec/capybara/mutation_observer_spec.rb
@@ -1,10 +1,10 @@
 require 'rack'
 require 'capybara'
 require 'capybara/rspec'
-require 'capybara/poltergeist'
+require 'capybara/cuprite'
 require 'capybara-mutation-observer'
 
-Capybara.default_driver = :poltergeist
+Capybara.default_driver = :cuprite
 Capybara.app = Rack::Directory.new('spec/public')
 Capybara.default_max_wait_time = 2
 Capybara::MutationObserver.default_max_wait_time = 10
@@ -49,7 +49,6 @@ feature 'Waiting for mutation' do
     # same reason as above - different initalization mechanism
     expect(page.evaluate_script("window._mutationState_.executionsWithoutMutation")).to eq(3)
   end
-
 
   # this test is for an ongoing mutation observer that
   # periodically resets


### PR DESCRIPTION
This is a 3-(or 4)-part PR, if you prefer that I create separate PRs please let me know.

1. Fixes the specs runner, which was failing because of recent changes to the `rack` gem (version >= 3 extracted `rack/handler` into the separate `rackup` gem). Also replaces the obsolete Polteregeist Capybara driver with the more modern [Cuprite](https://cuprite.rubycdp.com/)
2. Removes the redefining of Capybara DSL methods, which I think were not necessary, and were introducing errors anyway because they didn't account for keyword arguments
3. Makes `#ignoring_mutation` more useful by allowing nested calls (e.g. inside helper methods), and also allowing to call it without a block to disable/enable waiting for mutations for the rest of the spec
4. Some cleanups and a small typo fix to the README